### PR TITLE
Send raw plisSize instead of display friendly

### DIFF
--- a/francetransfert-worker/src/main/java/fr/gouv/culture/francetransfert/services/stat/StatServices.java
+++ b/francetransfert-worker/src/main/java/fr/gouv/culture/francetransfert/services/stat/StatServices.java
@@ -56,7 +56,6 @@ public class StatServices {
 
 			String sender = RedisUtils.getEmailSenderEnclosure(redisManager, enclosureId).toLowerCase();
 			double plisSize = RedisUtils.getTotalSizeEnclosure(redisManager, enclosureId);
-			String totalSizeEnclosure = FTFileUtils.byteCountToDisplaySize(plisSize);
 			Map<String, String> recipient = RedisUtils.getRecipientsEnclosure(redisManager, enclosureId);
 
 			String recipientList = recipient.keySet().stream().map(x -> x.toLowerCase().split("@")[1]).distinct()
@@ -76,7 +75,7 @@ public class StatServices {
 
 			// PLIS,DATE,Expediteur,destinataire,poids,hash_sender,type
 			csvPrinter.printRecord(enclosureId, date.format(DateTimeFormatter.ISO_LOCAL_DATE), sender.split("@")[1],
-					recipientList, totalSizeEnclosure, base64CryptoService.encodedHash(sender),
+					recipientList, plisSize, base64CryptoService.encodedHash(sender),
 					TypeStat.UPLOAD.getValue());
 
 			csvPrinter.flush();
@@ -96,7 +95,6 @@ public class StatServices {
 
 			String sender = RedisUtils.getEmailSenderEnclosure(redisManager, enclosureId).toLowerCase();
 			double plisSize = RedisUtils.getTotalSizeEnclosure(redisManager, enclosureId);
-			String totalSizeEnclosure = FTFileUtils.byteCountToDisplaySize(plisSize);
 
 			String recipientList = "";
 			String hashedMail = "";
@@ -119,7 +117,7 @@ public class StatServices {
 
 			// PLIS,DATE,Expediteur,destinataire,poids,hash_reciever,type
 			csvPrinter.printRecord(enclosureId, date.format(DateTimeFormatter.ISO_LOCAL_DATE), sender.split("@")[1],
-					recipientList, totalSizeEnclosure, hashedMail, TypeStat.DOWNLOAD.getValue());
+					recipientList, plisSize, hashedMail, TypeStat.DOWNLOAD.getValue());
 
 			csvPrinter.flush();
 			csvPrinter.close();


### PR DESCRIPTION
# Hello 👋🏽 

Dans le cadre du calcul de stats, j'ai besoin de sommer les tailles des plis pour calculer, par exemple, le total de Go envoyés dans un mois. En l'état, l'utilisation de cette colonne nécessite de reconvertir en une même unité (en B) donc de défaire le calcul de display fait de votre côté.

Ma proposition ici : Autant ne pas faire le calcul de display et laisser le poids brut. On peut aussi laisser les deux colonnes si vous pensez que le display size pli par pli présente un intérêt.

De cette manière :
- les réutilisations (y compris mes scripts) n'auront pas à reconvertir les unités pour explorer cette colonne
- moins de petits arrondis, c'est précis au byte près

Dispo pour en parler sur Tchap ! 